### PR TITLE
ignore unrecognized URIs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,9 @@ export function activate(): void {
         }
 
         const uri = resolveURI(editor.document.uri)
+        if (!uri) {
+            return
+        }
 
         const threads = await fetchDiscussionThreads({
             first: 10000,

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -2,7 +2,7 @@
  * Resolve a URI of the forms git://github.com/owner/repo?rev#path and file:///path to an absolute reference, using
  * the given base (root) URI.
  */
-export function resolveURI(uri: string): { repo: string; rev: string; path: string } {
+export function resolveURI(uri: string): { repo: string; rev: string; path: string } | null {
     const url = new URL(uri)
     if (url.protocol === 'git:') {
         return {
@@ -11,5 +11,5 @@ export function resolveURI(uri: string): { repo: string; rev: string; path: stri
             path: url.hash.slice(1),
         }
     }
-    throw new Error(`unrecognized URI: ${JSON.stringify(uri)} (supported URI schemes: git)`)
+    return null
 }


### PR DESCRIPTION
If a document has a URI other than `git:` (such as `comment:`, `https:`, etc., which occur in new experimental Sourcegraph features), the following error appears in the browser JS console:

```
Uncaught (in promise) Error: unrecognized URI: "comment://2" (supported URI schemes: git)
```

This change suppresses that error by skipping the attempt to decorate such files.